### PR TITLE
chore(deps): patch dependency updates (v0.5.4)

### DIFF
--- a/dist-test/ledger.test.d.ts
+++ b/dist-test/ledger.test.d.ts
@@ -1,1 +1,1 @@
-export {}
+export {};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@seneca/ledger",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "main": "dist/ledger.js",
   "type": "commonjs",
   "types": "dist/ledger.d.ts",
@@ -43,8 +43,8 @@
     "@seneca/entity-util": "^3.2.0",
     "@seneca/maintain": "^0.1.0",
     "@seneca/repl": "^9.1.0",
-    "@types/node": "^25.0.9",
-    "prettier": "3.8.0",
+    "@types/node": "^25.9.3",
+    "prettier": "3.8.4",
     "seneca-doc": "^2.1.3",
     "seneca-msg-test": "^4.1.0",
     "typescript": "^5.9.3"


### PR DESCRIPTION
## Summary

Patch-level dependency maintenance. Bumps version `0.5.3` → `0.5.4`.

### Updated
- `prettier` `3.8.0` → `3.8.4` (patch)
- `@types/node` `^25.0.9` → `^25.9.3` (in-range minor)

### Held back — risk
- `typescript` `5.9.3` → **6.0.3** (major). TypeScript 6.0 ships breaking changes that would affect this build:
  - `strict` enabled by default
  - `module` default → `esnext`, `target` default → `es2025`
  - `types` default → `[]`
  - removed/deprecated flags (`--outFile`, `--module amd/umd/systemjs`, `--moduleResolution node`, `esModuleInterop: false`)
  - `rootDir` default behavior change

  Deferred to a dedicated PR with proper tsconfig migration: #16 

### Verification
- `npm run build` — clean
- `npm test` — 6/6 pass